### PR TITLE
Use EnableRandomization from config in HealthcheckManager

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -4,6 +4,7 @@ metrics:
 proxy:
   port: 3000 # port for RPC gateway
   upstreamTimeout: "1s" # when is a request considered timed out
+  enableRandomization: true
 
 healthChecks:
   interval: "5s" # how often to do healthchecks
@@ -12,14 +13,19 @@ healthChecks:
   successThreshold: 1 # how many successes to be marked as healthy again
 
 targets:
-  - name: "QuickNode"
+  - name: "Blastapi"
     connection:
       http: # ws is supported by default, it will be a sticky connection.
-        url: "https://rpc.ankr.com/eth"
+        url: "https://eth-mainnet.public.blastapi.io"
         # compression: true # Specify if the target supports request compression
       # optional ws url for Solana configuration
       ws:
         url: "wss://solana.ws.node"
+  - name: "Flashbots"
+    connection:
+      http:
+        url: "https://rpc.flashbots.net/"
+
 
 exceptions:
 #   String to match in the response body

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -11,9 +11,10 @@ type HealthCheckConfig struct {
 	SuccessThreshold uint          `yaml:"successThreshold"`
 }
 
-type ProxyConfig struct { // nolint:revive
+type ProxyConfig struct {
 	Port            string        `yaml:"port"`
 	UpstreamTimeout time.Duration `yaml:"upstreamTimeout"`
+	EnableRandomization bool      `yaml:"enableRandomization"`
 }
 
 type TargetConnectionHTTP struct {

--- a/internal/rpcgateway/rpcgateway.go
+++ b/internal/rpcgateway/rpcgateway.go
@@ -98,6 +98,7 @@ func NewRPCGateway(config RPCGatewayConfig) *RPCGateway {
 		proxy.HealthcheckManagerConfig{
 			Targets: config.Targets,
 			Config:  config.HealthChecks,
+			Proxy: config.Proxy,
 			Solana:  config.Solana,
 		})
 	httpFailoverProxy := proxy.NewProxy(


### PR DESCRIPTION
Make the randomization of the client configurable in the proxy section of the config file.
In circumstances where predictability of the client used and the order of the fail waterfall is needed, this parameter can be set to false.